### PR TITLE
[WEBDEV-848] Unescape search result data in component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pugin-components",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "A shunter npm package containing dust components for beta.parliament.uk",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/html/components/card/search/html-tags-search-result.html
+++ b/test/fixtures/html/components/card/search/html-tags-search-result.html
@@ -1,0 +1,10 @@
+<div class="card">
+  <div class="card__details">
+    <h2><a href=some-url><b>Result</b> 1</a></h2>
+    <ul class="list--inline">
+      <li><span class="hint theme--grey-4 ">pdf</span></li>
+      <li><span class="url">some <b>shorter</b> url</span></li>
+    </ul>
+    <p>Some <b>text</b></p>
+  </div>
+</div>

--- a/test/fixtures/json/components/card/search/html-tags-search-result.json
+++ b/test/fixtures/json/components/card/search/html-tags-search-result.json
@@ -1,0 +1,25 @@
+{
+  "name": "card__search__search-result",
+  "data": {
+      "heading-text": "<b>Result</b> 1",
+      "url": "some-url",
+      "hints": [
+        {
+          "name": "partials__hint",
+          "data": {
+            "display": {
+              "data": [
+                {
+                "component": "theme",
+                "variant": "grey-4",
+                "content": "pdf"
+              }
+            ]
+            }
+          }
+        }
+      ],
+      "short-url": "some <b>shorter</b> url",
+      "paragraph-content": "Some <b>text</b>"
+  }
+}

--- a/test/unit/components/card/search/search-result.spec.js
+++ b/test/unit/components/card/search/search-result.spec.js
@@ -6,4 +6,10 @@ describe('Search result card dust component', function() {
   it('should return html from the dust component', function(done) {
     testHelper.shunterTest('search-result', 'components__card__search__search-result', 'components/card/search', done)
   });
+
+  context('unescaping html', function(done) {
+    it('should return html from the dust component', function(done) {
+      testHelper.shunterTest('html-tags-search-result', 'components__card__search__search-result', 'components/card/search', done)
+    });
+  });
 });

--- a/view/components/card/search/search-result.dust
+++ b/view/components/card/search/search-result.dust
@@ -3,7 +3,7 @@
 <div class="card">
   <div class="card__details">
     <h2>
-      <a href={data.url}>{data.heading-text}</a>
+      <a href={data.url}>{data.heading-text|s}</a>
     </h2>
       <ul class="list--inline">
 
@@ -15,9 +15,9 @@
           {/data.hints}
         {/data.hints}
         <li>
-          <span class="url">{data.short-url}</span>
+          <span class="url">{data.short-url|s}</span>
         </li>
       </ul>
-    <p>{data.paragraph-content}</p>
+    <p>{data.paragraph-content|s}</p>
   </div>
 </div>


### PR DESCRIPTION
Bing now adds HTML tags to the data we get from them. We currently escape them so we see the tags on the page. We want to unescape them so they get rendered as HTML.